### PR TITLE
adopt the new V5 token format

### DIFF
--- a/src/main/java/net/conjur/api/Token.java
+++ b/src/main/java/net/conjur/api/Token.java
@@ -1,10 +1,13 @@
 package net.conjur.api;
 
+import com.google.gson.annotations.SerializedName;
 import net.conjur.util.JsonSupport;
 import org.apache.commons.codec.binary.Base64;
 import org.joda.time.DateTime;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
+
+import java.nio.charset.StandardCharsets;
 
 /**
  * Represents a Conjur API authentication token.
@@ -17,14 +20,28 @@ public class Token {
 
     // Hold our fields in here to facilitate json serialization/deserialization
     private static class Fields {
-        public String data;
-        public String signature;
+        @SerializedName("protected")
+        private String protectedText;
+        private String payload;
+        private String signature;
+        private String expiration;//todo ???
+    }
+
+    private static class Payload {
+        @SerializedName("sub")
+        private String data;
+        @SerializedName("iat")
+        private String timestamp;
+    }
+
+    private static class ProtectedText {
+        @SerializedName("kid")
         public String key;
-        public String timestamp;
-        public String expiration;
     }
 
     private Fields fields;
+    private Payload payload;
+    private ProtectedText protectedText;
     private final String json;
     private DateTime timestamp;
     private DateTime expiration;
@@ -33,6 +50,7 @@ public class Token {
         this.json = json;
     }
 
+    //explanation can be found: https://gist.github.com/ryanprior/6afed20e85fae71386e4ede7ffa902b1
     private Fields fields(){
         if(fields == null){
             fields = JsonSupport.fromJson(json, Fields.class);
@@ -40,8 +58,22 @@ public class Token {
         return fields;
     }
 
+    private Payload payload(){
+        if(payload == null){
+            payload = JsonSupport.fromJson(fromBase64(fields().payload), Payload.class);
+        }
+        return payload;
+    }
+
+    private ProtectedText protectedText(){
+        if(protectedText == null){
+            protectedText = JsonSupport.fromJson(fromBase64(fields().protectedText), ProtectedText.class);
+        }
+        return protectedText;
+    }
+
     public String getData() {
-		return fields().data;
+		return payload().data;
 	}
 	
 	public String getSignature() {
@@ -49,12 +81,12 @@ public class Token {
 	}
 
 	public String getKey() {
-		return fields().key;
+		return protectedText().key;
 	}
 
     public DateTime getTimestamp(){
         if(timestamp == null){
-            timestamp = DATE_TIME_FORMATTER.parseDateTime(fields().timestamp);
+            timestamp = new DateTime((Long.parseLong(payload().timestamp) - 37) * 1000L);
         }
         return timestamp;
     }
@@ -91,7 +123,12 @@ public class Token {
         return new Token(json);
     }
 
-	public String toBase64(){
+    private String fromBase64(String base64){
+        // NB url safe mode *does not* work
+        return new String(Base64.decodeBase64(base64), StandardCharsets.UTF_8);
+    }
+
+    public String toBase64(){
         // NB url safe mode *does not* work
 		return Base64.encodeBase64String(toJson().getBytes());
 	}

--- a/src/main/java/net/conjur/api/Token.java
+++ b/src/main/java/net/conjur/api/Token.java
@@ -115,7 +115,7 @@ public class Token {
         return toJson();
     }
 
-	public String toJson(){
+	private String toJson(){
 		return json;
 	}
 
@@ -127,7 +127,7 @@ public class Token {
         return new String(Base64.decodeBase64(base64), StandardCharsets.UTF_8);
     }
 
-    public String toBase64(){
+    private String toBase64(){
         // NB url safe mode *does not* work
 		return Base64.encodeBase64String(toJson().getBytes());
 	}

--- a/src/main/java/net/conjur/api/Token.java
+++ b/src/main/java/net/conjur/api/Token.java
@@ -24,7 +24,7 @@ public class Token {
         private String protectedText;
         private String payload;
         private String signature;
-        private String expiration;//todo ???
+        private String expiration;
     }
 
     private static class Payload {
@@ -124,7 +124,6 @@ public class Token {
     }
 
     private String fromBase64(String base64){
-        // NB url safe mode *does not* work
         return new String(Base64.decodeBase64(base64), StandardCharsets.UTF_8);
     }
 

--- a/src/test/java/net/conjur/api/ConjurTest.java
+++ b/src/test/java/net/conjur/api/ConjurTest.java
@@ -14,7 +14,7 @@ import java.util.UUID;
  * Before running this test, verify that:
  *  - Conjur CE is running, healthy and accessible
  *  - A Policy that provides permission for this application to access a secret is loaded
- *  - This policy has an account and a variable named 'testSecret' related to that account
+ *  - This policy has an account and a variable named 'testVariable' related to that account
  *  - The following system properties are loaded:
  *      * CONJUR_ACCOUNT=myorg
  *      * CONJUR_AUTHN_LOGIN=host/myhost.example.com
@@ -23,7 +23,7 @@ import java.util.UUID;
  */
 public class ConjurTest {
 
-    private static final String VARIABLE_KEY = "test/testVariable";
+    private static final String VARIABLE_KEY = "testVariable";
     private static final String VARIABLE_VALUE = "testSecret";
     private static final String NON_EXISTING_VARIABLE_KEY = UUID.randomUUID().toString();
     private static final String NOT_FOUND_STATUS_CODE = "404";

--- a/src/test/java/net/conjur/api/ConjurTest.java
+++ b/src/test/java/net/conjur/api/ConjurTest.java
@@ -14,7 +14,7 @@ import java.util.UUID;
  * Before running this test, verify that:
  *  - Conjur CE is running, healthy and accessible
  *  - A Policy that provides permission for this application to access a secret is loaded
- *  - This policy has an account and a variable named 'testVariable' related to that account
+ *  - This policy has an account and a variable named 'test/testVariable' related to that account
  *  - The following system properties are loaded:
  *      * CONJUR_ACCOUNT=myorg
  *      * CONJUR_AUTHN_LOGIN=host/myhost.example.com
@@ -23,7 +23,7 @@ import java.util.UUID;
  */
 public class ConjurTest {
 
-    private static final String VARIABLE_KEY = "testVariable";
+    private static final String VARIABLE_KEY = "test/testVariable";
     private static final String VARIABLE_VALUE = "testSecret";
     private static final String NON_EXISTING_VARIABLE_KEY = UUID.randomUUID().toString();
     private static final String NOT_FOUND_STATUS_CODE = "404";


### PR DESCRIPTION
Hi Ryan,
Can you please review the change adopting the new v5 token format.
Did not handle the expiration so 8 minutes is always the token's timeout limit.
Please pay attention that StandardCharsets added requires Java minimum 1.7. Hope it is ok. Couldn't find the Java versioned used for Conjur V5.
Thanks