### PR TITLE
Adds support for token based authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.1.0] - 2018-08-24
+### Added
+- Adds support for token based authentication to support Kubernetes Authenticator
+
 ## [2.0.0](https://github.com/cyberark/conjur-api-java/releases/tag/v2.0.0) - 2018-07-12
 ### Added
 - License updated to Apache v2 - [PR #8](https://github.com/cyberark/conjur-api-java/pull/8)
@@ -21,7 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [1.3.0] - 2015-04-16
 ### Changed
-- Change variable behavior to reflect the fact that you may not have 'read' permission on 
+- Change variable behavior to reflect the fact that you may not have 'read' permission on
 a variable that you can 'execute' or 'update'.
 - Allow SSL hostname verification to be disabled in order to facilitate development and debugging.
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ keytool -import -alias conjur-youraccount -keystore "$JRE_HOME/lib/security/cace
 ## Examples
 
 ### Authorization Patterns
-All authorization options require the environment variables `CONJUR_ACCOUNT` and `CONJUR_APPLIANCE_URL` are set:
+All authorization options require the environment variables `CONJUR_ACCOUNT` and `CONJUR_APPLIANCE_URL` to be set:
 ```sh
 export CONJUR_ACCOUNT=<account specified during Conjur setup>
 export CONJUR_APPLIANCE_URL=<Conjur HTTPS endpoint>

--- a/README.md
+++ b/README.md
@@ -29,13 +29,13 @@ If you are using Maven to manage your project's dependencies, you can run `mvn i
 If you aren't using Maven, you can add the `jar` in the normal way. This `jar` can be found in
 the `target` directory created when you ran `mvn package`.
 
-Note that we ran `mvn package` without running the integration tests, since these require access to a Conjur instance. You can run the 
+Note that we ran `mvn package` without running the integration tests, since these require access to a Conjur instance. You can run the
 integration tests with `mvn package` once you finished with the configuration.
 
 ### Configuration
 
-The simplest way to configure the Conjur API is by using environment variables, which is often a bit more convenient. 
-Environment variables are mapped to configuration variables by prepending `CONJUR_` to the all-caps name of the 
+The simplest way to configure the Conjur API is by using environment variables, which is often a bit more convenient.
+Environment variables are mapped to configuration variables by prepending `CONJUR_` to the all-caps name of the
 configuration variable. For example, `appliance_url` is `CONJUR_APPLIANCE_URL`, `account` is `CONJUR_ACCOUNT` etc.  
 
 The following environment variables are mandatory for running the API: CONJUR_ACCOUNT, CONJUR_AUTHN_LOGIN, CONJUR_AUTHN_API_KEY & CONJUR_APPLIANCE_URL.
@@ -96,20 +96,49 @@ to your keystore like this:
 keytool -import -alias conjur-youraccount -keystore "$JRE_HOME/lib/security/cacerts"  -file ./conjur-youraccount.der
 ```
 
-## Basic Usage
+## Examples
 
-### Creating a Conjur Instance
+### Authorization Patterns
+All authorization options require the environment variables `CONJUR_ACCOUNT` and `CONJUR_APPLIANCE_URL` are set:
+```sh
+export CONJUR_ACCOUNT=<account specified during Conjur setup>
+export CONJUR_APPLIANCE_URL=<Conjur HTTPS endpoint>
+```
 
 A `Conjur` instance provides access to the individual Conjur services. To create one, you'll need the environment
 variables as described above. You will typically create a Conjur instance from these values in the following way:
 
+#### Environment Variables
+```sh
+# Additionally set the following environment variables:
+export CONJUR_AUTHN_LOGIN=<user/host identity>
+export CONJUR_AUTHN_API_KEY=<user/host API key>
+```
 ```java
+// Using environment variables
 Conjur conjur = new Conjur();
-
 ```
 
-where the Conjur object is logged in to the account & ready for use.
+#### Username and Password
+```java
+// Authenticate using provided username/hostname and password/API key
+Conjur conjur = new Conjur('host/host-id', 'api-key');
+Conjur conjur = new Conjur('username', 'password');
+```
 
+#### Credentials
+```java
+// Authenticate using a Credentials object
+Credentials credentials = new Credentials('username', 'password');
+Conjur conjur = new Conjur(credentials);
+```
+
+#### Authorization Token
+```java
+String authTokenString = new String(Files.readAllBytes(Paths.get('path/to/conjur/authentication/token.json')));
+Token token = Token.fromJson(authTokenString);
+Conjur conjur = new Conjur(token);
+```
 
 ### Variable Operations
 
@@ -119,13 +148,9 @@ A variable can have one or more (up to 20) secrets associated with it, and order
 You will typically add secrets to variables & retrieve secrets from variables in the following way:
 
 ```java
-Conjur conjur = new Conjur();
-
 conjur.variables().addSecret(VARIABLE_KEY, VARIABLE_VALUE);
-
 String retrievedSecret = conjur.variables().retrieveSecret(VARIABLE_KEY);
 ```
-
 
 ## JAX-RS Implementations
 

--- a/README.md
+++ b/README.md
@@ -135,8 +135,16 @@ Conjur conjur = new Conjur(credentials);
 
 #### Authorization Token
 ```java
-String authTokenString = new String(Files.readAllBytes(Paths.get('path/to/conjur/authentication/token.json')));
-Token token = Token.fromJson(authTokenString);
+Token token = Token.fromFile(Paths.get('path/to/conjur/authentication/token.json'));
+Conjur conjur = new Conjur(token);
+```
+
+Alternatively, to use the `CONJUR_AUTHN_TOKEN_FILE` environment variable:
+```bash
+export CONJUR_AUTHN_TOKEN_FILE="path/to/conjur/authentication/token.json"
+```
+```java
+Token token = Token.fromEnv();
 Conjur conjur = new Conjur(token);
 ```
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ If you are using Maven to manage your project's dependencies, you can run `mvn i
 <dependency>
   <groupId>net.conjur.api</groupId>
   <artifactId>conjur-api</artifactId>
-  <version>2.0.0</version>
+  <version>2.1.0</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>net.conjur.api</groupId>
     <artifactId>conjur-api</artifactId>
-    <version>2.0.0</version>
+    <version>2.1.0</version>
 
     <name>Conjur</name>
     <description>Client for the Conjur API</description>

--- a/src/main/java/net/conjur/api/Conjur.java
+++ b/src/main/java/net/conjur/api/Conjur.java
@@ -31,11 +31,15 @@ public class Conjur {
         variables = new Variables(credentials);
     }
 
-    
+
+    /**
+     * Create a Conjur instance that uses a ResourceClient &amp; an AuthnClient constructed with the given credentials
+     * @param token the conjur authorization token to use
+     */
     public Conjur(Token token) {
         variables = new Variables(token);
     }
-    
+
     /**
      * Get a Variables instance configured with the same parameters as this instance.
      * @return the variables instance

--- a/src/main/java/net/conjur/api/Conjur.java
+++ b/src/main/java/net/conjur/api/Conjur.java
@@ -31,6 +31,11 @@ public class Conjur {
         variables = new Variables(credentials);
     }
 
+    
+    public Conjur(Token token) {
+        variables = new Variables(token);
+    }
+    
     /**
      * Get a Variables instance configured with the same parameters as this instance.
      * @return the variables instance

--- a/src/main/java/net/conjur/api/Token.java
+++ b/src/main/java/net/conjur/api/Token.java
@@ -8,6 +8,12 @@ import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
 
 import java.nio.charset.StandardCharsets;
+import java.nio.charset.Charset;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 /**
  * Represents a Conjur API authentication token.
@@ -17,6 +23,7 @@ public class Token {
     private static final DateTimeFormatter DATE_TIME_FORMATTER =
             // tokens use dates like 2013-10-01 18:48:32 UTC
             DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss ZZZ");
+    private static final String TOKEN_FILE_ENV_VARIABLE = "CONJUR_AUTHN_TOKEN_FILE";
 
     // Hold our fields in here to facilitate json serialization/deserialization
     private static class Fields {
@@ -121,6 +128,29 @@ public class Token {
 
     public static Token fromJson(String json){
         return new Token(json);
+    }
+
+    public static Token fromFile(Path filepath, Charset encoding)
+        throws IOException {
+        byte[] encodedJson = Files.readAllBytes(filepath);
+        String json = new String(encodedJson, encoding);
+        return fromJson(json);
+    }
+
+    public static Token fromFile(Path filepath)
+        throws IOException {
+        return fromFile(filepath, StandardCharsets.UTF_8);
+    }
+
+    public static Token fromEnv(Charset encoding) 
+        throws IOException {
+        String tokenFilePath = System.getenv(TOKEN_FILE_ENV_VARIABLE);
+        return fromFile(Paths.get(tokenFilePath), encoding);
+    }
+
+    public static Token fromEnv()
+        throws IOException {
+        return fromEnv(StandardCharsets.UTF_8);
     }
 
     private String fromBase64(String base64){

--- a/src/main/java/net/conjur/api/Variables.java
+++ b/src/main/java/net/conjur/api/Variables.java
@@ -11,6 +11,10 @@ public class Variables {
                 credentials.getUsername(), credentials.getPassword(), Endpoints.fromSystemProperties());
     }
 
+    public Variables(Token token) {
+        resourceClient = new ResourceClient(token, Endpoints.fromSystemProperties());
+    }
+    
     public String retrieveSecret(String variableId) {
         return resourceClient.retrieveSecret(variableId);
     }

--- a/src/main/java/net/conjur/api/clients/AuthnK8sClient.java
+++ b/src/main/java/net/conjur/api/clients/AuthnK8sClient.java
@@ -1,0 +1,21 @@
+package net.conjur.api.clients;
+import net.conjur.api.AuthnProvider;
+import net.conjur.api.Token;
+
+public class AuthnK8sClient implements AuthnProvider {
+
+	private Token token;
+	
+	public AuthnK8sClient(Token token) {
+		this.token = token;
+	}
+	
+	public Token authenticate() {
+		return token;
+	}
+
+	public Token authenticate(boolean useCachedToken) {
+		return this.authenticate();
+	}
+	
+}

--- a/src/main/java/net/conjur/api/clients/AuthnTokenClient.java
+++ b/src/main/java/net/conjur/api/clients/AuthnTokenClient.java
@@ -2,11 +2,11 @@ package net.conjur.api.clients;
 import net.conjur.api.AuthnProvider;
 import net.conjur.api.Token;
 
-public class AuthnK8sClient implements AuthnProvider {
+public class AuthnTokenClient implements AuthnProvider {
 
 	private Token token;
 	
-	public AuthnK8sClient(Token token) {
+	public AuthnTokenClient(Token token) {
 		this.token = token;
 	}
 	

--- a/src/main/java/net/conjur/api/clients/ResourceClient.java
+++ b/src/main/java/net/conjur/api/clients/ResourceClient.java
@@ -1,16 +1,17 @@
 package net.conjur.api.clients;
 
-import net.conjur.api.Endpoints;
-import net.conjur.api.ResourceProvider;
-import net.conjur.util.EncodeUriComponent;
-import net.conjur.util.rs.TokenAuthFilter;
-
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.Response;
+
+import net.conjur.api.Endpoints;
+import net.conjur.api.ResourceProvider;
+import net.conjur.api.Token;
+import net.conjur.util.EncodeUriComponent;
+import net.conjur.util.rs.TokenAuthFilter;
 
 /**
  * Conjur service client.
@@ -26,6 +27,13 @@ public class ResourceClient implements ResourceProvider {
         init(username, password);
 	}
 
+	// Build ResourceClient using a K8S auth token
+	public ResourceClient(final Token token, final Endpoints endpoints) {
+        this.endpoints = endpoints;
+
+        init(token);
+	}
+	
     public String retrieveSecret(String variableId) {
         Response response = secrets.path(variableId).request().get(Response.class);
         validateResponse(response);
@@ -51,6 +59,14 @@ public class ResourceClient implements ResourceProvider {
         secrets = client.target(getEndpoints().getSecretsUri());
     }
 
+    private void init(Token token){
+        final ClientBuilder builder = ClientBuilder.newBuilder()
+                .register(new TokenAuthFilter(new AuthnK8sClient(token)));
+
+        Client client = builder.build();
+
+        secrets = client.target(getEndpoints().getSecretsUri());
+    }
     // TODO orenbm: Remove when we have a response filter to handle this
     private void validateResponse(Response response) {
         int status = response.getStatus();

--- a/src/main/java/net/conjur/api/clients/ResourceClient.java
+++ b/src/main/java/net/conjur/api/clients/ResourceClient.java
@@ -27,7 +27,7 @@ public class ResourceClient implements ResourceProvider {
         init(username, password);
 	}
 
-	// Build ResourceClient using a K8S auth token
+	// Build ResourceClient using a Conjur auth token
 	public ResourceClient(final Token token, final Endpoints endpoints) {
         this.endpoints = endpoints;
 
@@ -61,7 +61,7 @@ public class ResourceClient implements ResourceProvider {
 
     private void init(Token token){
         final ClientBuilder builder = ClientBuilder.newBuilder()
-                .register(new TokenAuthFilter(new AuthnK8sClient(token)));
+                .register(new TokenAuthFilter(new AuthnTokenClient(token)));
 
         Client client = builder.build();
 


### PR DESCRIPTION
#### What does this PR do?
Adds support for using a Conjur authentication token for authorization. This allows the library to leverage Kubernetes authentication, removing the need for host and API keys.
 
#### Any background context you want to provide?
The code for this PR comes from the USAA engineering team.

#### What ticket does this PR close?
Closes #22 

#### Link to build in Jenkins (if appropriate)
https://jenkins.conjur.net/job/cyberark--conjur-api-java/job/authn-kubernetes/ is green, but note that no additional tests have been added.

#### Has the Version and Changelog been updated?
Yes.