### PR TITLE
Update JavaDoc comment to allow project to build without errors

### DIFF
--- a/src/main/java/net/conjur/api/Credentials.java
+++ b/src/main/java/net/conjur/api/Credentials.java
@@ -27,7 +27,9 @@ public class Credentials {
     }
 
     /**
-     * Creates a Credentials instance from the system properties {@link Credentials#CONJUR_AUTHN_LOGIN_PROPERTY} & {@link Credentials#CONJUR_AUTHN_API_KEY_PROPERTY}
+     * Creates a Credentials instance from the system properties
+     * {@link Credentials#CONJUR_AUTHN_LOGIN_PROPERTY} and
+     * {@link Credentials#CONJUR_AUTHN_API_KEY_PROPERTY}
      * @return the credentials stored in the system property.
      */
     public static Credentials fromSystemProperties(){


### PR DESCRIPTION
Minor fix to the comment format in Credentials.java.  Change allows Maven to build the project without encountering JavaDoc errors.