### PR TITLE
Include Shade plugin to build jar with dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -143,6 +143,23 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <!-- Plugin to create jar with dependencies -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <shadedClassifierName>with-dependencies</shadedClassifierName>
+                            <shadedArtifactAttached>true</shadedArtifactAttached>
+                    </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
This PR updates the Maven build configuration to build both the normal `conjur-api-{version}.jar` and a new jar that includes the API depdendencies (`conjur-api-{version}-with-dependencies.jar`) for simple applications or for getting started with the API.