### PR TITLE
74 [contrib] Enable use of custom SSLContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Implemented [#74](https://github.com/cyberark/conjur-api-java/issues/74)
+- Updated code to enable adding custom javax.net.ssl.SSLContext to Conjur which
+  enables us to set up a trust between application and Conjur server from Java
+  code
+- README has been updated with example SSLContext setup and it's use in Conjur
+  class constructors
+
 ## [2.2.1] - 2020-05-08
 ### Fixed
 - README has been updated to reflect the correct/expected usage of this SDK ([#70](https://github.com/cyberark/conjur-api-java/issues/70),

--- a/README.md
+++ b/README.md
@@ -260,6 +260,32 @@ conjur-default, May 6, 2020, trustedCertEntry,
 There you have it! Now you are all configured to start leveraging the Conjur Java API in
 your Java program.
 
+### Programmatic Set Up Trust Between App and Conjur using SSLContext
+
+We can set up a trust between the client application and a Conjur server using
+Java javax.net.ssl.SSLContext. This can be done from Java code during
+Conjur class initialization.
+
+Usable in Kubernetes/OpenShift environment to setup TLS trust with Conjur
+server dynamically from the Kubernetes secret and/or configmap data.
+
+```java
+final String conjurTlsCaPath = "/var/conjur-config/tls-ca.pem";
+
+final CertificateFactory cf = CertificateFactory.getInstance("X.509");
+final FileInputStream certIs = new FileInputStream(conjurTlsCaPath);
+final Certificate cert = cf.generateCertificate(certIs);
+
+final KeyStore ks = KeyStore.getInstance("JKS");
+ks.load(null);
+ks.setCertificateEntry("conjurTlsCaPath", cert);
+final TrustManagerFactory tmf = TrustManagerFactory.getInstance("SunX509");
+tmf.init(ks);
+
+SSLContext conjurSslContext = SSLContext.getInstance("TLS");
+conjurSslContext.init(null, tmf.getTrustManagers(), null);
+```
+
 ## Authorization Examples
 
 As mentioned in the [Configuration](#configuration) section, you can provide varying ways
@@ -287,6 +313,8 @@ import net.conjur.api.Conjur;
 
 // Configured using environment variables
 Conjur conjur = new Conjur();
+// or using custom SSLContext setup as conjurSslContext variable
+Conjur conjur = new Conjur(conjurSslContext);
 ```
 
 ### System Properties
@@ -303,6 +331,8 @@ import net.conjur.api.Conjur;
 
 // Configured using system properties
 Conjur conjur = new Conjur();
+// or using custom SSLContext setup as conjurSslContext variable
+Conjur conjur = new Conjur(conjurSslContext);
 ```
 
 ### System Properties with Maven
@@ -320,6 +350,8 @@ import net.conjur.api.Conjur;
 
 // Configured using system properties
 Conjur conjur = new Conjur();
+// or using custom SSLContext setup as conjurSslContext variable
+Conjur conjur = new Conjur(conjurSslContext);
 ```
 
 ### Username and Password
@@ -337,6 +369,8 @@ import net.conjur.api.Conjur;
 Conjur conjur = new Conjur('host/host-id', 'password-or-api-key');
 // or
 Conjur conjur = new Conjur('username', 'password-or-api-key');
+// or using custom SSLContext setup as conjurSslContext variable
+Conjur conjur = new Conjur('username', 'password-or-api-key', conjurSslContext);
 ```
 
 ### Credentials
@@ -354,6 +388,8 @@ import net.conjur.api.Credentials;
 // regarding how 'password-or-api-key' is processed.
 Credentials credentials = new Credentials('username', 'password-or-api-key');
 Conjur conjur = new Conjur(credentials);
+// or using custom SSLContext setup as conjurSslContext variable
+Conjur conjur = new Conjur(credentials, conjurSslContext);
 ```
 
 ### Authorization Token
@@ -371,6 +407,8 @@ import net.conjur.api.Token;
 
 Token token = Token.fromFile(Paths.get('path/to/conjur/authentication/token.json'));
 Conjur conjur = new Conjur(token);
+// or using custom SSLContext setup as conjurSslContext variable
+Conjur conjur = new Conjur(token, conjurSslContext);
 ```
 
 Alternatively, use the `CONJUR_AUTHN_TOKEN_FILE` environment variable:
@@ -387,6 +425,8 @@ import net.conjur.api.Token;
 
 Token token = Token.fromEnv();
 Conjur conjur = new Conjur(token);
+// or using custom SSLContext setup as conjurSslContext variable
+Conjur conjur = new Conjur(token, conjurSslContext);
 ```
 
 ## Client APIs
@@ -400,10 +440,15 @@ a secret from Conjur, so we provide some sample code for this use case below.
 The client can be instantiated with any of these methods:
 ```java
 Conjur client = Conjur();
+Conjur client = Conjur(SSLContext sslContext);
 Conjur client = Conjur(String username, String password);
+Conjur client = Conjur(String username, String password, SSLContext sslContext);
 Conjur client = Conjur(String username, String password, String authnUrl);
+Conjur client = Conjur(String username, String password, String authnUrl, SSLContext sslContext);
 Conjur client = Conjur(Credentials credentials);
+Conjur client = Conjur(Credentials credentials, SSLContext sslContext);
 Conjur client = Conjur(Token token);
+Conjur client = Conjur(Token token, SSLContext sslContext);
 ```
 
 _Note:_ **As mentioned before, if you use the default `CONJUR_AUTHN_URL` value or your

--- a/README.md
+++ b/README.md
@@ -217,8 +217,8 @@ ks.setCertificateEntry("conjurTlsCaPath", cert);
 final TrustManagerFactory tmf = TrustManagerFactory.getInstance("SunX509");
 tmf.init(ks);
 
-SSLContext conjurSslContext = SSLContext.getInstance("TLS");
-conjurSslContext.init(null, tmf.getTrustManagers(), null);
+SSLContext conjurSSLContext = SSLContext.getInstance("TLS");
+conjurSSLContext.init(null, tmf.getTrustManagers(), null);
 ```
 
 ### JVM-level trust
@@ -321,8 +321,8 @@ import net.conjur.api.Conjur;
 
 // Configured using environment variables
 Conjur conjur = new Conjur();
-// or using custom SSLContext setup as conjurSslContext variable
-Conjur conjur = new Conjur(conjurSslContext);
+// or using custom SSLContext setup as conjurSSLContext variable
+Conjur conjur = new Conjur(conjurSSLContext);
 ```
 
 ### System Properties
@@ -339,8 +339,8 @@ import net.conjur.api.Conjur;
 
 // Configured using system properties
 Conjur conjur = new Conjur();
-// or using custom SSLContext setup as conjurSslContext variable
-Conjur conjur = new Conjur(conjurSslContext);
+// or using custom SSLContext setup as conjurSSLContext variable
+Conjur conjur = new Conjur(conjurSSLContext);
 ```
 
 ### System Properties with Maven
@@ -358,8 +358,8 @@ import net.conjur.api.Conjur;
 
 // Configured using system properties
 Conjur conjur = new Conjur();
-// or using custom SSLContext setup as conjurSslContext variable
-Conjur conjur = new Conjur(conjurSslContext);
+// or using custom SSLContext setup as conjurSSLContext variable
+Conjur conjur = new Conjur(conjurSSLContext);
 ```
 
 ### Username and Password
@@ -377,8 +377,8 @@ import net.conjur.api.Conjur;
 Conjur conjur = new Conjur('host/host-id', 'password-or-api-key');
 // or
 Conjur conjur = new Conjur('username', 'password-or-api-key');
-// or using custom SSLContext setup as conjurSslContext variable
-Conjur conjur = new Conjur('username', 'password-or-api-key', conjurSslContext);
+// or using custom SSLContext setup as conjurSSLContext variable
+Conjur conjur = new Conjur('username', 'password-or-api-key', conjurSSLContext);
 ```
 
 ### Credentials
@@ -396,8 +396,8 @@ import net.conjur.api.Credentials;
 // regarding how 'password-or-api-key' is processed.
 Credentials credentials = new Credentials('username', 'password-or-api-key');
 Conjur conjur = new Conjur(credentials);
-// or using custom SSLContext setup as conjurSslContext variable
-Conjur conjur = new Conjur(credentials, conjurSslContext);
+// or using custom SSLContext setup as conjurSSLContext variable
+Conjur conjur = new Conjur(credentials, conjurSSLContext);
 ```
 
 ### Authorization Token
@@ -415,8 +415,8 @@ import net.conjur.api.Token;
 
 Token token = Token.fromFile(Paths.get('path/to/conjur/authentication/token.json'));
 Conjur conjur = new Conjur(token);
-// or using custom SSLContext setup as conjurSslContext variable
-Conjur conjur = new Conjur(token, conjurSslContext);
+// or using custom SSLContext setup as conjurSSLContext variable
+Conjur conjur = new Conjur(token, conjurSSLContext);
 ```
 
 Alternatively, use the `CONJUR_AUTHN_TOKEN_FILE` environment variable:
@@ -433,8 +433,8 @@ import net.conjur.api.Token;
 
 Token token = Token.fromEnv();
 Conjur conjur = new Conjur(token);
-// or using custom SSLContext setup as conjurSslContext variable
-Conjur conjur = new Conjur(token, conjurSslContext);
+// or using custom SSLContext setup as conjurSSLContext variable
+Conjur conjur = new Conjur(token, conjurSSLContext);
 ```
 
 ## Client APIs

--- a/README.md
+++ b/README.md
@@ -187,17 +187,17 @@ values (like the API key) in source-controlled property files!
 
 ## Set Up Trust Between App and Conjur
 
-By default, the Conjur appliance generates and uses self-signed SSL certificates (Java-specific
-certificates known as cacerts). Without trusting them, your Java app will not be able to connect
-to the Conjur server over APIs and so you will need to configure your app to trust them. You can
-accomplish this by using the [Client-level `SSLContext`](#client--level-trust) when creating
-the client or with a [JVM-level trust](#jvm--level-trust) by loading the Conjur certificate into
-Java's CA keystore that holds the list of all the allowed certificates for https connections.
+By default, the Conjur appliance generates and uses self-signed SSL certificates. Without
+trusting them, your Java app will not be able to connect to the Conjur server over APIs
+and so you will need to configure your app to trust them. You can accomplish this by using
+the [Client-level `SSLContext`](#client--level-trust) when creating the client or with a
+[JVM-level trust](#jvm--level-trust) by loading the Conjur certificate into Java's CA
+keystore that holds the list of all the allowed certificates for https connections.
 
 ### Client-level trust
 
 We can set up a trust between the client application and a Conjur server using
-Java javax.net.ssl.SSLContext. This can be done from Java code during
+Java `javax.net.ssl.SSLContext`. This can be done from Java code during
 Conjur class initialization.
 
 Usable in Kubernetes/OpenShift environment to setup TLS trust with Conjur
@@ -223,11 +223,9 @@ conjurSslContext.init(null, tmf.getTrustManagers(), null);
 
 ### JVM-level trust
 
-By default, the Conjur appliance generates and uses self-signed SSL certificates (Java-specific
-certificates known as cacerts). Without trusting them, your Java app will not be able to connect
-to the Conjur server over APIs and so you will need to configure your app to trust them. You can
-accomplish this by loading the Conjur certificate into Java's CA keystore that holds the list of
-all the allowed certificates for https connections.
+For a JVM-level trust between Conjur and the API client, you need to load the Conjur
+certificate into Java's CA keystore that holds the list of all the allowed certificates
+for https connections.
 
 First, we need to get a copy of this certificate, which you can get using `openssl`. Run the
 following step from a terminal with OpenSSL that has access to Conjur:

--- a/src/main/java/net/conjur/api/Conjur.java
+++ b/src/main/java/net/conjur/api/Conjur.java
@@ -1,5 +1,7 @@
 package net.conjur.api;
 
+import javax.net.ssl.SSLContext;
+
 /**
  * Entry point for the Conjur API client.
  */
@@ -15,12 +17,30 @@ public class Conjur {
     }
 
     /**
+     * Create a Conjur instance that uses credentials from the system properties
+     * @param sslContext the {@link SSLContext} to use for connections to Conjur server
+     */
+    public Conjur(SSLContext sslContext){
+        this(Credentials.fromSystemProperties(), sslContext);
+    }
+
+    /**
      * Create a Conjur instance that uses a ResourceClient &amp; an AuthnClient constructed with the given credentials
      * @param username username for the Conjur identity to authenticate as
      * @param password password or api key for the Conjur identity to authenticate as
      */
     public Conjur(String username, String password) {
         this(new Credentials(username, password));
+    }
+
+    /**
+     * Create a Conjur instance that uses a ResourceClient &amp; an AuthnClient constructed with the given credentials
+     * @param username username for the Conjur identity to authenticate as
+     * @param password password or api key for the Conjur identity to authenticate as
+     * @param sslContext the {@link SSLContext} to use for connections to Conjur server
+     */
+    public Conjur(String username, String password, SSLContext sslContext) {
+        this(new Credentials(username, password), sslContext);
     }
 
     /**
@@ -35,19 +55,47 @@ public class Conjur {
 
     /**
      * Create a Conjur instance that uses a ResourceClient &amp; an AuthnClient constructed with the given credentials
+     * @param username username for the Conjur identity to authenticate as
+     * @param password password or api key for the Conjur identity to authenticate as
+     * @param authnUrl the conjur authentication url
+     * @param sslContext the {@link SSLContext} to use for connections to Conjur server
+     */
+    public Conjur(String username, String password, String authnUrl, SSLContext sslContext) {
+        this(new Credentials(username, password, authnUrl), sslContext);
+    }
+
+    /**
+     * Create a Conjur instance that uses a ResourceClient &amp; an AuthnClient constructed with the given credentials
      * @param credentials the conjur identity to authenticate as
      */
     public Conjur(Credentials credentials) {
-        variables = new Variables(credentials);
+        this(credentials, null);
     }
 
+    /**
+     * Create a Conjur instance that uses a ResourceClient &amp; an AuthnClient constructed with the given credentials
+     * @param credentials the conjur identity to authenticate as
+     * @param sslContext the {@link SSLContext} to use for connections to Conjur server
+     */
+    public Conjur(Credentials credentials, SSLContext sslContext) {
+        variables = new Variables(credentials, sslContext);
+    }
 
     /**
      * Create a Conjur instance that uses a ResourceClient &amp; an AuthnClient constructed with the given credentials
      * @param token the conjur authorization token to use
      */
     public Conjur(Token token) {
-        variables = new Variables(token);
+        this(token, null);
+    }
+
+    /**
+     * Create a Conjur instance that uses a ResourceClient &amp; an AuthnClient constructed with the given credentials
+     * @param token the conjur authorization token to use
+     * @param sslContext the {@link SSLContext} to use for connections to Conjur server
+     */
+    public Conjur(Token token, SSLContext sslContext) {
+        variables = new Variables(token, sslContext);
     }
 
     /**

--- a/src/main/java/net/conjur/api/Variables.java
+++ b/src/main/java/net/conjur/api/Variables.java
@@ -1,5 +1,7 @@
 package net.conjur.api;
 
+import javax.net.ssl.SSLContext;
+
 import net.conjur.api.clients.ResourceClient;
 
 public class Variables {
@@ -7,11 +9,20 @@ public class Variables {
     private ResourceClient resourceClient;
 
     public Variables(Credentials credentials) {
-        resourceClient = new ResourceClient(credentials, Endpoints.fromCredentials(credentials));
+        this(credentials, null);
+    }
+
+    public Variables(Credentials credentials, SSLContext sslContext) {
+        resourceClient =
+                new ResourceClient(credentials, Endpoints.fromCredentials(credentials), sslContext);
     }
 
     public Variables(Token token) {
-        resourceClient = new ResourceClient(token, Endpoints.fromSystemProperties());
+        this(token, null);
+    }
+
+    public Variables(Token token, SSLContext sslContext) {
+        resourceClient = new ResourceClient(token, Endpoints.fromSystemProperties(), sslContext);
     }
 
     public String retrieveSecret(String variableId) {


### PR DESCRIPTION
Added code enabling to set custom SSLContext from Java code during
Conjur class initialization.
Usable in k8s/OpenShift environment to setup TLS trust with Conjur
server dynamically from k8s secret and/or configmap data.

Original PR: https://github.com/cyberark/conjur-api-java/pull/75

Connected to #74 

CC: @vvidovic