### PR TITLE
Properly encode spaces in URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Encode spaces to "%20" instead of "+". This encoding fixes an issue where Conjur
+  variables that have spaces were not encoded correctly
+  ([https://github.com/cyberark/conjur-api-java#78](https://github.com/cyberark/conjur-api-java/issues/78))
 
 ## [2.2.1] - 2020-05-08
 ### Fixed

--- a/src/main/java/net/conjur/api/clients/ResourceClient.java
+++ b/src/main/java/net/conjur/api/clients/ResourceClient.java
@@ -36,15 +36,25 @@ public class ResourceClient implements ResourceProvider {
     }
 
     public String retrieveSecret(String variableId) {
-        Response response = secrets.path(variableId).request().get(Response.class);
+        Response response = secrets.path(encodeVariableId(variableId))
+          .request().get(Response.class);
         validateResponse(response);
 
         return response.readEntity(String.class);
     }
 
     public void addSecret(String variableId, String secret) {
-        Response response = secrets.path(EncodeUriComponent.encodeUriComponent(variableId)).request().post(Entity.text(secret), Response.class);
+        Response response = secrets.path(encodeVariableId(variableId)).request()
+          .post(Entity.text(secret), Response.class);
         validateResponse(response);
+    }
+
+    // The "encodeUriComponent" method encodes plus signs into %2B and spaces
+    // into '+'. However, our server decodes plus signs into plus signs in the
+    // retrieveSecret request so we need to replace the plus signs (which are
+    // spaces) into %20.
+    private String encodeVariableId(String variableId) {
+        return EncodeUriComponent.encodeUriComponent(variableId).replaceAll("\\+", "%20");
     }
 
     private Endpoints getEndpoints() {

--- a/src/test/java/net/conjur/api/ConjurTest.java
+++ b/src/test/java/net/conjur/api/ConjurTest.java
@@ -25,6 +25,7 @@ import java.util.UUID;
 public class ConjurTest {
 
     private static final String VARIABLE_KEY = "test/testVariable";
+    private static final String VARIABLE_KEY_WITH_SPACES = "test/var with spaces";
     private static final String VARIABLE_VALUE = "testSecret";
     private static final String NON_EXISTING_VARIABLE_KEY = UUID.randomUUID().toString();
     private static final String NOT_FOUND_STATUS_CODE = "404";
@@ -47,11 +48,20 @@ public class ConjurTest {
     public void testAddSecretAndRetrieveSecret() {
         Conjur conjur = new Conjur();
 
-        conjur.variables().addSecret(VARIABLE_KEY, VARIABLE_VALUE);
+        String[] variableIds = {
+            VARIABLE_KEY,
+            VARIABLE_KEY_WITH_SPACES
+        };
 
-        String retrievedSecret = conjur.variables().retrieveSecret(VARIABLE_KEY);
+        String retrievedSecret;
+        for (String variableId : variableIds)
+        {
+            conjur.variables().addSecret(variableId, VARIABLE_VALUE);
 
-        Assert.assertEquals(retrievedSecret, VARIABLE_VALUE);
+            retrievedSecret = conjur.variables().retrieveSecret(variableId);
+
+            Assert.assertEquals(retrievedSecret, VARIABLE_VALUE);
+        }
     }
 
     @Test

--- a/test-policy/root.yml
+++ b/test-policy/root.yml
@@ -1,8 +1,12 @@
 - !policy
   id: test
   body:
-    - !variable
-      id: testVariable
+    - &variables
+      - !variable
+        id: testVariable
+
+      - !variable
+        id: var with spaces
 
     - !user
       id: alice
@@ -20,7 +24,7 @@
       member: !host myapp
 
     - !permit
-      resource: !variable testVariable
+      resource: *variables
       privileges: [ read, execute, update]
       roles: !group secrets-users
 


### PR DESCRIPTION
Connected to #78 

The "encodeUriComponent" method encodes plus signs into %2B and spaces
into '+'. However, our server decodes plus signs into plus signs in the
retrieveSecret request so we need to replace the plus signs (which are
spaces) into %20.