### PR TITLE
Add missing Maven Central requirements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,8 @@
   <packaging>jar</packaging>
 
   <name>Conjur</name>
-  <description>Client for the Conjur API</description>
+  <description>Programmatic Java access to the Conjur API</description>
+  <url>https://github.com/cyberark/conjur-api-java</url>
 
   <licenses>
     <license>


### PR DESCRIPTION
- Added `url` tag under main project settings
- Adjusted description to match Github description

The URL tag was missing from previous commits, and it
required for maven central publishing.