### PR TITLE
Improved wording of v3.0.0 release CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   ([https://github.com/cyberark/conjur-api-java#78](https://github.com/cyberark/conjur-api-java/issues/78))
 
 ### Added
-- Implemented [#74](https://github.com/cyberark/conjur-api-java/issues/74)
+- Enabled setting custom SSLContext for TLS connection to Conjur server.
+  [cyberark/conjur-api-java#74](https://github.com/cyberark/conjur-api-java/issues/74)
 - Updated code to enable adding custom javax.net.ssl.SSLContext to Conjur which
   enables us to set up a trust between application and Conjur server from Java
   code


### PR DESCRIPTION
Old description of adding ability to set an SSLContext was inadequate in
the CHANGELOG so this commit fixes it to be a bit more descriptive and
conformant.

### What ticket does this PR close?
N/A

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation