### PR TITLE
Fix nexus-staging deployment

### DIFF
--- a/bin/deploy-release.sh
+++ b/bin/deploy-release.sh
@@ -22,4 +22,4 @@ docker run --rm \
   /bin/bash -ec "gpg --batch --passphrase-file /gpg_password --trust-model always --import /gpg_key
                 mvn versions:set -DnewVersion=${TAG}
                 mvn --settings settings.xml clean deploy -Dmaven.test.skip=true -P ossrh,sign
-                mvn nexus-staging:release"
+                mvn --settings settings.xml nexus-staging:release -Dmaven.test.skip=true -P ossrh,sign"


### PR DESCRIPTION
### What does this PR do?
Deployment script commands were not using the correct profile
which provided access to the `nexus-staging` groupID and credentials.

### What ticket does this PR close?
~

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [X] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [X] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [X] This PR does not require updating any documentation