### PR TITLE
Updating naming for Conjur editions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ To work in this codebase, you will need the latest version of the [Java JDK](htt
 This project is container-based and therefore, you will need [Docker](https://hub.docker.com/) in order to make and view your changes.
 
 ### Access to Conjur Registry (for contributing to testing ONLY)
-To contribute to testing, you will need both the Conjur OSS and DAP (Enterprise). You shouldn't have a problem pulling down the OSS image, but to pull the Enterprise image, you must be granted access to the Conjur registry.
+To contribute to testing, you will need both the Conjur Open Source and Enterprise. You shouldn't have a problem pulling down the Open Source image, but to pull the Enterprise image, you must be granted access to the Conjur registry.
 
 You will want to get in contact with the Infrastructure team via the [CyberArk Commons](https://discuss.cyberarkcommons.org/) to be granted access. If you have been granted access, run: `docker login registry.tld`.
  
@@ -29,7 +29,7 @@ Before making changes, it is recommended that the test script is run first to en
 You can run the test script in your shell like so:
 `./test.sh`
 
-_NOTE:_ The tests (for both Conjur OSS and DAP) are part of the build so if a change is made to the actual API, but the tests fail, the build will also fail.
+_NOTE:_ The tests (for both Conjur Open Source and Enterprise) are part of the build so if a change is made to the actual API, but the tests fail, the build will also fail.
 
 ## Troubleshooting Steps
 This section includes helpful troubleshooting hints to help you navigate the codebase and resolve problems that you might be experiencing during development.
@@ -45,7 +45,7 @@ This section includes helpful troubleshooting hints to help you navigate the cod
     To do so: 
     1. `docker exec` into the test container and run `keytool -list -keystore $JRE_HOME/lib/security/cacerts -alias <IMPORTED_CERT_ALIAS>`. The alias of the certificate can be found in the test script.
         1. If import was successful, the certificate fingerprint (SHA) should be returned.
-    2. Navigate to `https://localhost:<PORT_OF_DAP/CONJUR_CONTAINER>` in your browser (make sure the DAP/Conjur container is still up and running). 
+    2. Navigate to `https://localhost:<PORT_OF_CONJUR_CONTAINER>` in your browser (make sure the Conjur container is still up and running). 
         1. You can find the exact ports by taking a look at each container's exposed ports in the `docker-compose.yml` file. 
         2. You can keep containers up by commenting out the `finish` function in the test script.
     3. For instructions on how to view certificates in browsers, take a look [here](https://www.globalsign.com/en/blog/how-to-view-ssl-certificate-details/).

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 Conjur API for Java
 ===================
-Programmatic Java access to the Conjur API (for both Conjur OSS and Enterprise/DAP versions).
+Programmatic Java access to the Conjur API (for both Conjur Open Source and Enterprise/DAP versions).
 This Java SDK allows developers to build new apps in Java that communicate with Conjur by
 invoking our Conjur API to perform operations on stored data (add, retrieve, etc).
 
 ## Table of Contents
 
 - [Prerequisites](#prerequisites)
-  * [Using conjur-api-java with Conjur OSS](#using-conjur-api-java-with-conjur-oss)
+  * [Using conjur-api-java with Conjur Open Source](#using-conjur-api-java-with-conjur-open-source)
 - [Setup](#setup)
   * [Using the Source Code](#using-the-source-code)
   * [Using the Jarfile](#using-the-jarfile)
@@ -54,9 +54,9 @@ and these for installation of [Enterprise/DAP](https://docs.cyberark.com/Product
 Once Conjur and the Conjur CLI are running in the background, you are ready to start
 setting up your Java app to work with our Conjur Java API!
 
-### Using conjur-api-java with Conjur OSS 
+### Using conjur-api-java with Conjur Open Source 
 
-Are you using this project with [Conjur OSS](https://github.com/cyberark/conjur)? Then we 
+Are you using this project with [Conjur Open Source](https://github.com/cyberark/conjur)? Then we 
 **strongly** recommend choosing the version of this project to use from the latest [Conjur OSS 
 suite release](https://docs.conjur.org/Latest/en/Content/Overview/Conjur-OSS-Suite-Overview.html). 
 Conjur maintainers perform additional testing on the suite release versions to ensure 
@@ -223,7 +223,7 @@ variable.
 
 ### Environment Variables
 
-In Conjur (both OSS and DAP), environment variables are mapped to configuration variables
+In Conjur (both Open Source and Enterprise), environment variables are mapped to configuration variables
 by prepending `CONJUR_` to the all-caps name of the configuration variable. For example,
 `appliance_url` is `CONJUR_APPLIANCE_URL`, `account` is `CONJUR_ACCOUNT` etc.
 
@@ -232,7 +232,7 @@ order use the Conjur API if no other configuration is done (e.g. over system pro
 CLI parameters):
 
 - `CONJUR_APPLIANCE_URL` - The URL of the Conjur instance you are connecting to. When connecting to
-  DAP configured for high availability, this should be the URL of the master load balancer (if
+  Conjur Enterprise configured for high availability, this should be the URL of the master load balancer (if
   performing read and write operations) or the URL of a follower load balancer (if performing
   read-only operations).
 - `CONJUR_ACCOUNT` - Conjur account that you are connecting to. This value is set during Conjur deployment.


### PR DESCRIPTION
Updating naming for Conjur editions

- converts `Conjur OSS` to `Conjur Open Source`
- converts `DAP`/`Dynamic Access Provider` to `Conjur Enterprise`
- maintains `Conjur OSS Suite` and `Conjur Open Source Suite`

This is part of an automated batch of PRs across many repos listed in [cyberark/community#92](https://github.com/cyberark/community/issues/92)
