### PR TITLE
Upgrade OpenJDK base image

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM openjdk:8
+FROM openjdk:17-jdk-bullseye
 
 MAINTAINER Conjur Inc
 

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -97,7 +97,7 @@ function initializeDapCert() {
      -alias cuke-master -v \
      -trustcacerts \
      -noprompt \
-     -keystore "${JAVA_PATH}/jre/lib/security/cacerts" \
+     -keystore "${JAVA_PATH}/lib/security/cacerts" \
      -file /test-cert/conjur-cucumber.der -storepass changeit"
   docker exec ${dap_test_cid} ${import_command}
 }

--- a/bin/utils.sh
+++ b/bin/utils.sh
@@ -86,7 +86,7 @@ function initializeOssCert() {
     -alias cucumber \
     -v -trustcacerts \
     -noprompt \
-    -keystore "${JAVA_PATH}/jre/lib/security/cacerts" \
+    -keystore "${JAVA_PATH}/lib/security/cacerts" \
     -file /test-cert/conjur-cucumber.der -storepass changeit"
   docker exec ${conjur_test_cid} ${import_command}
 }

--- a/pom.xml
+++ b/pom.xml
@@ -189,6 +189,13 @@
         <artifactId>junit</artifactId>
         <version>4.13.1</version>
       </dependency>
+
+      <!-- must include JAXB manually post Java 9 -->
+        <dependency>
+          <groupId>jakarta.xml.bind</groupId>
+          <artifactId>jakarta.xml.bind-api</artifactId>
+          <version>2.3.3</version>
+      </dependency> 
     </dependencies>
 
     <build>
@@ -214,6 +221,7 @@
                 <CONJUR_AUTHN_LOGIN>${env.CONJUR_AUTHN_LOGIN}</CONJUR_AUTHN_LOGIN>
                 <CONJUR_AUTHN_API_KEY>${env.CONJUR_AUTHN_API_KEY}</CONJUR_AUTHN_API_KEY>
               </systemPropertyVariables>
+              <argLine>--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.net=ALL-UNNAMED</argLine>
             </configuration>
           </plugin>
 


### PR DESCRIPTION
### What does this PR do?
Upgrades the OpenJDK base image for testing to Java 17, fixes some minor issues that arose with the version change

### What ticket does this PR close?
Addresses Snyk security issue with OpenJDK 8 in test scripts

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation