### PR TITLE
Fix Jenkins build: error when retrieving API key

### DIFF
--- a/bin/test.sh
+++ b/bin/test.sh
@@ -126,7 +126,7 @@ function runOssTests() {
 
   conjur_client_cid=$(docker-compose ps -q client)
 
-  api_key_admin=$(docker-compose exec -T conjur rails r "print Credentials['cucumber:user:admin'].api_key")
+  api_key_admin=$(docker-compose exec -T conjur conjurctl role retrieve-key cucumber:user:admin)
 
   # Execute OSS tests
   docker-compose run --rm \
@@ -141,9 +141,9 @@ function runOssHttpsTests() {
   echo "Running https tests"
   echo '------------------------------------------------------------'
 
-  api_key_admin=$(docker-compose exec -T conjur rails r "print Credentials['cucumber:user:admin'].api_key")
-  api_key_alice=$(docker-compose exec -T conjur rails r "print Credentials['cucumber:user:alice@test'].api_key")
-  api_key_myapp=$(docker-compose exec -T conjur rails r "print Credentials['cucumber:host:test/myapp'].api_key")
+  api_key_admin=$(docker-compose exec -T conjur conjurctl role retrieve-key cucumber:user:admin)
+  api_key_alice=$(docker-compose exec -T conjur conjurctl role retrieve-key cucumber:user:alice@test)
+  api_key_myapp=$(docker-compose exec -T conjur conjurctl role retrieve-key cucumber:host:test/myapp)
 
   echo 'api keys:'
   echo 'user admin api key = ' ${api_key_admin}

--- a/bin/utils.sh
+++ b/bin/utils.sh
@@ -23,7 +23,7 @@ function loadOssPolicy() {
 
   conjur_client_cid=$(docker-compose ps -q client)
 
-  api_key=$(docker-compose exec -T conjur rails r "print Credentials['cucumber:user:admin'].api_key")
+  api_key=$(docker-compose exec -T conjur conjurctl role retrieve-key cucumber:user:admin)
 
   # Copy test-policy into a /tmp/test-policy within the possum container
   docker cp test-policy ${conjur_client_cid}:/tmp


### PR DESCRIPTION
### What does this PR do?

Jenkins build was failing when retrieving user API keys when setting up test infra:
```
++ docker-compose exec -T conjur rails r 'print Credentials['\''cucumber:user:admin'\''].api_key'
+ api_key='[deprecated] Dry::Struct::Value is deprecated and will be removed in the next major version
/opt/conjur-server/app/domain/util/submodules.rb:7:in `const_get'\''
1h9spyz1y7jf2t2tfq8wx18jnmpravbbzvxfk1pt1svapqw3rasaae'
```

The deprecation message was being used in setup as part of the API key. While the source of this message needs to be addressed, the build can be fixed by retrieving the API keys with `conjurctl` instead of `rails`:
```
docker-compose exec -T conjur rails r "print Credentials['cucumber:user:admin'].api_key
 vv
docker-compose exec -T conjur conjurctl role retrieve-key cucumber:user:admin
```

### What ticket does this PR close?

CyberArk internal issue link: [ONYX-19910](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-19910)

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation