### PR TITLE
Bump version to 3.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.0.3] - 2022-05-31
+
 ### Security
+- Upgraded OpenJDK Dockerfile base image to `17-jdk-bullseye`.
+  [cyberark/conjur-api-java#107](https://github.com/cyberark/conjur-api-java/pull/107)
 - Upgraded nginx Dockerfile base image to fix CVE-2022-0778 and CVE-2022-1292.
   [cyberark/conjur-api-java#111](https://github.com/cyberark/conjur-api-java/pull/111)
 
@@ -83,7 +87,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Authn tokens now use the new Conjur 5 format - [PR #21](https://github.com/cyberark/conjur-api-java/pull/21)
 - Configuration change. When using environment variables, use `CONJUR_AUTHN_LOGIN` and `CONJUR_AUTHN_API_KEY` now instead of `CONJUR_CREDENTIALS` - https://github.com/cyberark/conjur-api-java/commit/60344308fc48cb5380c626e612b91e1e720c03fb
 
-[Unreleased]: https://github.com/cyberark/conjur-api-java/compare/v3.0.2...HEAD
+[Unreleased]: https://github.com/cyberark/conjur-api-java/compare/v3.0.3...HEAD
+[3.0.3]: https://github.com/cyberark/conjur-api-java/compare/v3.0.2...v3.0.3
 [3.0.2]: https://github.com/cyberark/conjur-api-java/compare/v3.0.1...v3.0.2
 [3.0.1]: https://github.com/cyberark/conjur-api-java/compare/v3.0.0...v3.0.1
 [3.0.0]: https://github.com/cyberark/conjur-api-java/compare/v2.2.1...v3.0.0

--- a/NOTICES.txt
+++ b/NOTICES.txt
@@ -8,21 +8,26 @@ of the license associated with each component.
 
 SECTION 1: Common Development and Distribution License 1.1
 
->>> https://mvnrepository.com/artifact/javax.ws.rs/javax.ws.rs-api/2.0.1
+>>> https://mvnrepository.com/artifact/javax.ws.rs/javax.ws.rs-api/2.0
 
 SECTION 2: GNU General Public License 1.1
 
->>> https://mvnrepository.com/artifact/javax.ws.rs/javax.ws.rs-api/2.0.1
+>>> https://mvnrepository.com/artifact/javax.ws.rs/javax.ws.rs-api/2.0
 
 SECTION 3: APACHE-2.0
 
->>> https://mvnrepository.com/artifact/commons-codec/commons-codec/1.7
->>> https://mvnrepository.com/artifact/com.google.code.gson/gson/2.3.1
+>>> https://mvnrepository.com/artifact/commons-codec/commons-codec/1.15
+>>> https://mvnrepository.com/artifact/com.google.code.gson/gson/2.9.0
 >>> https://mvnrepository.com/artifact/joda-time/joda-time/2.3
+>>> https://mvnrepository.com/artifact/org.apache.cxf/cxf-rt-rs-client/3.5.1
 
-SECTION 4: MIT
+SECTION 4: Eclipse Distribution License 1.0
 
->>> https://mvnrepository.com/artifact/info.cukes/cucumber-java/1.1.5
+>>> https://mvnrepository.com/artifact/jakarta.xml.bind/jakarta.xml.bind-api/2.3.3
+
+SECTION 5: Eclipse Public License 1.0
+
+>>> https://mvnrepository.com/artifact/junit/junit/4.13.1
 
 
 APPENDIX: Standard License Files and Templates
@@ -33,13 +38,15 @@ APPENDIX: Standard License Files and Templates
 
 >>> APACHE-2.0
 
->>> MIT
+>>> Eclipse Public License 1.0
+
+>>> Eclipse Distribution License 1.0
 
 --------------- SECTION 1: Common Development and Distribution License 1.1 -----
 
 Common Development and Distribution License 1.1 is applicable to the following component(s).
 
->>> https://mvnrepository.com/artifact/javax.ws.rs/javax.ws.rs-api/2.0.1
+>>> https://mvnrepository.com/artifact/javax.ws.rs/javax.ws.rs-api/2.0
 
 
     DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
@@ -78,7 +85,7 @@ Common Development and Distribution License 1.1 is applicable to the following c
 
 GNU General Public License 1.1 is applicable to the following component(s).
 
->>> https://mvnrepository.com/artifact/javax.ws.rs/javax.ws.rs-api/2.0.1
+>>> https://mvnrepository.com/artifact/javax.ws.rs/javax.ws.rs-api/2.0
 
     DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
     Copyright (c) 2011-2017 Oracle and/or its affiliates. All rights reserved.
@@ -116,10 +123,10 @@ GNU General Public License 1.1 is applicable to the following component(s).
 
 APACHE-2.0 is applicable to the following component(s).
 
->>> https://mvnrepository.com/artifact/commons-codec/commons-codec/1.7
+>>> https://mvnrepository.com/artifact/commons-codec/commons-codec/1.15
 
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2002 The Apache Software Foundation
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -133,9 +140,9 @@ APACHE-2.0 is applicable to the following component(s).
    See the License for the specific language governing permissions and
    limitations under the License.
 
->>> https://mvnrepository.com/artifact/com.google.code.gson/gson/2.3.1
+>>> https://mvnrepository.com/artifact/com.google.code.gson/gson/2.9.0
 
-Copyright [yyyy] [name of copyright owner]
+Copyright 2008 Google Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -151,7 +158,7 @@ limitations under the License.
 
 >>> https://mvnrepository.com/artifact/joda-time/joda-time/2.3
 
-Copyright [yyyy] [name of copyright owner]
+Copyright 2001 Stephen Colebourne
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -165,33 +172,33 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
---------------- SECTION 4: MIT ---------------
+>>> https://mvnrepository.com/artifact/org.apache.cxf/cxf-rt-rs-client/3.5.1
 
-MIT is applicable to the following component(s).
+Copyright 2008 The Apache Software Foundation
 
->>> https://mvnrepository.com/artifact/info.cukes/cucumber-java/1.1.5
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-Copyright (c) 2008-2013 The Cucumber Organisation
+    http://www.apache.org/licenses/LICENSE-2.0
 
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
+--------------- SECTION 4: Eclipse Distribution License 1.0 ---------------------
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+Eclipse Distribution License 1.0 is applicable to the following components:
 
+>>> https://mvnrepository.com/artifact/jakarta.xml.bind/jakarta.xml.bind-api/2.3.3
+
+--------------- SECTION 5: Eclipse Public License 1.0 ---------------------
+
+Eclipse Public License 1.0 is applicable to the following components:
+
+>>> https://mvnrepository.com/artifact/junit/junit/4.13.1
 
 =============== APPENDIX: License Files and Templates ==============
 
@@ -1017,23 +1024,239 @@ That's all there is to it!
    limitations under the License.
 
 
---------------- APPENDIX 4: MIT (Template) ---------------------
+--------------- APPENDIX 4: Eclipse Distribution License 1.0 --------------------
 
-Copyright <YEAR> <COPYRIGHT HOLDER>
+Copyright (c) 2007, Eclipse Foundation, Inc. and its licensors.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to use,
-copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
-Software, and to permit persons to whom the Software is furnished to do so, subject
-to the following conditions:
+All rights reserved.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+Redistribution and use in source and binary forms, with or without 
+modification, are permitted provided that the following conditions are 
+met:
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
-INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
-PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
-HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+Redistributions of source code must retain the above copyright notice, 
+this list of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright notice, 
+this list of conditions and the following disclaimer in the documentation 
+and/or other materials provided with the distribution.
+
+Neither the name of the Eclipse Foundation, Inc. nor the names of its
+contributors may be used to endorse or promote products derived from 
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+--------------- APPENDIX 5: Eclipse Public License 1.0 --------------------
+
+Eclipse Public License - v 1.0
+THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE PUBLIC
+LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION OF THE PROGRAM
+CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+
+1. DEFINITIONS
+
+"Contribution" means:
+
+    a) in the case of the initial Contributor, the initial code and
+    documentation distributed under this Agreement, and
+    b) in the case of each subsequent Contributor:
+    i) changes to the Program, and
+    ii) additions to the Program;
+    where such changes and/or additions to the Program originate from and are
+    distributed by that particular Contributor. A Contribution 'originates' from
+    a Contributor if it was added to the Program by such Contributor itself or
+    anyone acting on such Contributor's behalf. Contributions do not include
+    additions to the Program which: (i) are separate modules of software
+    distributed in conjunction with the Program under their own license
+    agreement, and (ii) are not derivative works of the Program.
+
+"Contributor" means any person or entity that distributes the Program.
+
+"Licensed Patents" mean patent claims licensable by a Contributor which are
+necessarily infringed by the use or sale of its Contribution alone or when
+combined with the Program.
+
+"Program" means the Contributions distributed in accordance with this Agreement.
+
+"Recipient" means anyone who receives the Program under this Agreement,
+including all Contributors.
+
+2. GRANT OF RIGHTS
+
+    a) Subject to the terms of this Agreement, each Contributor hereby grants
+    Recipient a non-exclusive, worldwide, royalty-free copyright license to
+    reproduce, prepare derivative works of, publicly display, publicly perform,
+    distribute and sublicense the Contribution of such Contributor, if any, and
+    such derivative works, in source code and object code form.
+
+    b) Subject to the terms of this Agreement, each Contributor hereby grants
+    Recipient a non-exclusive, worldwide, royalty-free patent license under
+    Licensed Patents to make, use, sell, offer to sell, import and otherwise
+    transfer the Contribution of such Contributor, if any, in source code and
+    object code form. This patent license shall apply to the combination of the
+    Contribution and the Program if, at the time the Contribution is added by
+    the Contributor, such addition of the Contribution causes such combination
+    to be covered by the Licensed Patents. The patent license shall not apply to
+    any other combinations which include the Contribution. No hardware per se is
+    licensed hereunder.
+
+    c) Recipient understands that although each Contributor grants the licenses
+    to its Contributions set forth herein, no assurances are provided by any
+    Contributor that the Program does not infringe the patent or other
+    intellectual property rights of any other entity. Each Contributor disclaims
+    any liability to Recipient for claims brought by any other entity based on
+    infringement of intellectual property rights or otherwise. As a condition to
+    exercising the rights and licenses granted hereunder, each Recipient hereby
+    assumes sole responsibility to secure any other intellectual property rights
+    needed, if any. For example, if a third party patent license is required to
+    allow Recipient to distribute the Program, it is Recipient's responsibility
+    to acquire that license before distributing the Program.
+
+    d) Each Contributor represents that to its knowledge it has sufficient
+    copyright rights in its Contribution, if any, to grant the copyright license
+    set forth in this Agreement.
+
+3. REQUIREMENTS
+
+A Contributor may choose to distribute the Program in object code form under its
+own license agreement, provided that:
+
+    a) it complies with the terms and conditions of this Agreement; and
+    b) its license agreement:
+    i) effectively disclaims on behalf of all Contributors all warranties and
+    conditions, express and implied, including warranties or conditions of title
+    and non-infringement, and implied warranties or conditions of
+    merchantability and fitness for a particular purpose;
+    ii) effectively excludes on behalf of all Contributors all liability for
+    damages, including direct, indirect, special, incidental and consequential
+    damages, such as lost profits;
+    iii) states that any provisions which differ from this Agreement are offered
+    by that Contributor alone and not by any other party; and
+    iv) states that source code for the Program is available from such
+    Contributor, and informs licensees how to obtain it in a reasonable manner
+    on or through a medium customarily used for software exchange.
+
+When the Program is made available in source code form:
+
+    a) it must be made available under this Agreement; and
+    b) a copy of this Agreement must be included with each copy of the Program.
+
+Contributors may not remove or alter any copyright notices contained within the
+Program.
+
+Each Contributor must identify itself as the originator of its Contribution, if
+any, in a manner that reasonably allows subsequent Recipients to identify the
+originator of the Contribution.
+
+4. COMMERCIAL DISTRIBUTION
+
+Commercial distributors of software may accept certain responsibilities with
+respect to end users, business partners and the like. While this license is
+intended to facilitate the commercial use of the Program, the Contributor who
+includes the Program in a commercial product offering should do so in a manner
+which does not create potential liability for other Contributors. Therefore, if
+a Contributor includes the Program in a commercial product offering, such
+Contributor ("Commercial Contributor") hereby agrees to defend and indemnify
+every other Contributor ("Indemnified Contributor") against any losses, damages
+and costs (collectively "Losses") arising from claims, lawsuits and other legal
+actions brought by a third party against the Indemnified Contributor to the
+extent caused by the acts or omissions of such Commercial Contributor in
+connection with its distribution of the Program in a commercial product
+offering. The obligations in this section do not apply to any claims or Losses
+relating to any actual or alleged intellectual property infringement. In order
+to qualify, an Indemnified Contributor must: a) promptly notify the Commercial
+Contributor in writing of such claim, and b) allow the Commercial Contributor to
+control, and cooperate with the Commercial Contributor in, the defense and any
+related settlement negotiations. The Indemnified Contributor may participate in
+any such claim at its own expense.
+
+For example, a Contributor might include the Program in a commercial product
+offering, Product X. That Contributor is then a Commercial Contributor. If that
+Commercial Contributor then makes performance claims, or offers warranties
+related to Product X, those performance claims and warranties are such
+Commercial Contributor's responsibility alone. Under this section, the
+Commercial Contributor would have to defend claims against the other
+Contributors related to those performance claims and warranties, and if a court
+requires any other Contributor to pay any damages as a result, the Commercial
+Contributor must pay those damages.
+
+5. NO WARRANTY
+
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, THE PROGRAM IS PROVIDED ON AN
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF TITLE,
+NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Each
+Recipient is solely responsible for determining the appropriateness of using and
+distributing the Program and assumes all risks associated with its exercise of
+rights under this Agreement , including but not limited to the risks and costs
+of program errors, compliance with applicable laws, damage to or loss of data,
+programs or equipment, and unavailability or interruption of operations.
+
+6. DISCLAIMER OF LIABILITY
+
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, NEITHER RECIPIENT NOR ANY
+CONTRIBUTORS SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION LOST
+PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE EXERCISE OF ANY RIGHTS
+GRANTED HEREUNDER, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+7. GENERAL
+
+If any provision of this Agreement is invalid or unenforceable under applicable
+law, it shall not affect the validity or enforceability of the remainder of the
+terms of this Agreement, and without further action by the parties hereto, such
+provision shall be reformed to the minimum extent necessary to make such
+provision valid and enforceable.
+
+If Recipient institutes patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Program itself
+(excluding combinations of the Program with other software or hardware)
+infringes such Recipient's patent(s), then such Recipient's rights granted under
+Section 2(b) shall terminate as of the date such litigation is filed.
+
+All Recipient's rights under this Agreement shall terminate if it fails to
+comply with any of the material terms or conditions of this Agreement and does
+not cure such failure in a reasonable period of time after becoming aware of
+such noncompliance. If all Recipient's rights under this Agreement terminate,
+Recipient agrees to cease use and distribution of the Program as soon as
+reasonably practicable. However, Recipient's obligations under this Agreement
+and any licenses granted by Recipient relating to the Program shall continue and
+survive.
+
+Everyone is permitted to copy and distribute copies of this Agreement, but in
+order to avoid inconsistency the Agreement is copyrighted and may only be
+modified in the following manner. The Agreement Steward reserves the right to
+publish new versions (including revisions) of this Agreement from time to time.
+No one other than the Agreement Steward has the right to modify this Agreement.
+The Eclipse Foundation is the initial Agreement Steward. The Eclipse Foundation
+may assign the responsibility to serve as the Agreement Steward to a suitable
+separate entity. Each new version of the Agreement will be given a
+distinguishing version number. The Program (including Contributions) may always
+be distributed subject to the version of the Agreement under which it was
+received. In addition, after a new version of the Agreement is published,
+Contributor may elect to distribute the Program (including its Contributions)
+under the new version. Except as expressly stated in Sections 2(a) and 2(b)
+above, Recipient receives no rights or licenses to the intellectual property of
+any Contributor under this Agreement, whether expressly, by implication,
+estoppel or otherwise. All rights in the Program not expressly granted under
+this Agreement are reserved.
+
+This Agreement is governed by the laws of the State of New York and the
+intellectual property laws of the United States of America. No party to this
+Agreement will bring a legal action under this Agreement more than one year
+after the cause of action arose. Each party waives its rights to a jury trial in
+any resulting litigation.

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <artifactId>conjur-api</artifactId>
   <!-- Only bump version number,
   SNAPSHOT is automatically removed during release deployments -->
-  <version>3.0.2-SNAPSHOT</version>
+  <version>3.0.3-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Conjur</name>
@@ -247,6 +247,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-shade-plugin</artifactId>
+            <version>3.3.0</version>
             <executions>
               <execution>
                 <goals>


### PR DESCRIPTION
### What does this PR do?

- Update `NOTICES.txt`:
  - Bump versions:
    - `javax.ws.rs-api`
    - `commons-codec`
    - `gson`
  - Add licenses:
    - Apache 2.0 License for `cxf-rt-rs-client`
    - Eclipse Distribution License 1.0 for `jakarta.xml.bind-api`
    - Eclipse Public License 1.0 for `junit`
- Update `CHANGELOG.md` for 3.0.3 release
- Bump project version in `pom.xml`
- Add `version` field to `maven-shade-plugin` entry in `pom.xml`, to resolve the following warning:

  ```
  Some problems were encountered while building the effective model for com.cyberark.conjur.api:conjur-api:jar:3.0.3-SNAPSHOT

  'build.plugins.plugin.version' for org.apache.maven.plugins:maven-shade-plugin is missing. @ line 247, column 19

  It is highly recommended to fix these problems because they threaten the stability of your build.

  For this reason, future Maven versions might no longer support building such malformed projects.
  ```

### What ticket does this PR close?

CyberArk internal issue link: [ONYX-21133](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-21133)

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation