### PR TITLE
Bump Apache cxf to 4.0.0, upgrade dockerfile base images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Security
+- Update Dockerfile base images, bump Apache cxf to 3.5.5
+  [cyberark/conjur-api-java#113](https://github.com/cyberark/conjur-api-java/issues/113)
+
 ## [3.0.3] - 2022-05-31
 
 ### Security

--- a/Dockerfile.nginx
+++ b/Dockerfile.nginx
@@ -1,4 +1,4 @@
-FROM nginx:1.21.6
+FROM nginx:1.23.3
 
 MAINTAINER Conjur Inc
 

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM openjdk:17-jdk-bullseye
+FROM openjdk:21-slim
 
 MAINTAINER Conjur Inc
 

--- a/pom.xml
+++ b/pom.xml
@@ -160,7 +160,7 @@
       <dependency>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-rt-rs-client</artifactId>
-        <version>3.5.1</version>
+        <version>3.5.5</version>
       </dependency>
 
       <!-- JSON support -->


### PR DESCRIPTION
### What does this PR do?
Update dependencies to address Snyk vulnerabilities:

- Bump Apache cxf to 3.5.5
- Bump openjdk base image to 21-slim
- Bump nginx base image to 1.23.3

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation