### PR TITLE
Upgrade nginx to 1.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Security
+- Update nginx to 1.24 in Dockerfile.nginx
+  [cyberark/conjur-api-java#118](https://github.com/cyberark/conjur-api-java/issues/118)
+
 ### Changed
 - Avoid calling `login` for host
   [cyberark/conjur-api-java#117](https://github.com/cyberark/conjur-api-java/pull/117)

--- a/Dockerfile.nginx
+++ b/Dockerfile.nginx
@@ -1,4 +1,4 @@
-FROM nginx:1.23.3
+FROM nginx:1.24
 
 MAINTAINER Conjur Inc
 


### PR DESCRIPTION
### What does this PR do?

This pull request upgrades the Dockerfile's nginx image to 1.24.

#### Change log
- [X] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [X] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [X] This PR does not require updating any documentation