### PR TITLE
Fix builds

### DIFF
--- a/bin/utils.sh
+++ b/bin/utils.sh
@@ -7,13 +7,13 @@ function createOssEnvironment() {
 
   # Build OSS test container & start the cluster
   docker-compose build --pull client conjur postgres test test-https conjur-proxy-nginx
-  export CONJUR_APPLIANCE_URL="http://conjur:3000"
+  export CONJUR_APPLIANCE_URL="http://conjur"
   docker-compose up -d client conjur postgres test-https
 
   # Delay to allow time for conjur to come up
   # TODO: remove this once we have HEALTHCHECK in place
   echo 'Waiting for conjur server to be healthy'
-  docker-compose exec -T conjur conjurctl wait -r 60 -p 3000
+  docker-compose exec -T conjur conjurctl wait -r 60 -p 80
 }
 
 function loadOssPolicy() {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,9 @@
 version: '2'
 services:
   postgres:
-    image: postgres:9.3
+    image: postgres:15
+    environment:
+      POSTGRES_PASSWORD: pa55w0rd
 
   conjur:
     image: cyberark/conjur:latest
@@ -9,7 +11,7 @@ services:
     environment:
       CONJUR_ACCOUNT: cucumber
       PORT: 80
-      DATABASE_URL: postgres://postgres@postgres/postgres
+      DATABASE_URL: postgres://postgres:pa55w0rd@postgres/postgres
       CONJUR_DATA_KEY: "W0BuL8iTr/7QvtjIluJbrb5LDAnmXzmcpxkqihO3dXA="
       RAILS_ENV: development
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,12 +8,12 @@ services:
     command: server -a cucumber
     environment:
       CONJUR_ACCOUNT: cucumber
-      PORT: 3000
+      PORT: 80
       DATABASE_URL: postgres://postgres@postgres/postgres
       CONJUR_DATA_KEY: "W0BuL8iTr/7QvtjIluJbrb5LDAnmXzmcpxkqihO3dXA="
       RAILS_ENV: development
     ports:
-      - "3000:3000"
+      - "80:80"
     depends_on:
       - postgres
 
@@ -59,7 +59,7 @@ services:
     volumes:
       - ./target:/conjurinc/api-java/target
     environment:
-      CONJUR_APPLIANCE_URL: http://conjur:3000
+      CONJUR_APPLIANCE_URL: http://conjur
       CONJUR_ACCOUNT: cucumber
 
   # Spin up container for EE testing

--- a/test-proxy/default.conf
+++ b/test-proxy/default.conf
@@ -18,7 +18,7 @@ server {
     access_log            /var/log/nginx/access.log;
 
     location / {
-      proxy_pass http://conjur:3000;
+      proxy_pass http://conjur:80;
     }
 
     #error_page  404              /404.html;


### PR DESCRIPTION
### What does this PR do?
Fix pipeline failures and upgrade to Postgres 15.

Currently there is an issue with matching the request host to the allowed hosts in the Conjur dev environment. It's unclear why this is happening since the the regex `config.hosts << /conjur[0-9]*/` should allow requests to the `conjur` hostname in the docker compose network. The easiest fix without modifying any Conjur internals is to run the service on the default port (80) for HTTP requests which for some reason circumvents this issue.

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation