### PR TITLE
#122 Change JUnit scope to test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -199,6 +199,7 @@
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
         <version>4.13.1</version>
+        <scope>test</scope>
       </dependency>
 
       <!-- must include JAXB manually post Java 9 -->


### PR DESCRIPTION
### What does this PR do?

Change the maven scope of JUnit to test, so that the dependency on JUnit is not exposed to consumers of the library, so that they are not forced to include the JUnit library if not desired.

Testing this change should be covered by validating that the library still compiles and that the unit tests run.

### What ticket does this PR close?
Resolves #122

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [X] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [X] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [X] This PR does not require updating any documentation